### PR TITLE
Express mode

### DIFF
--- a/src/dara/search/core.py
+++ b/src/dara/search/core.py
@@ -52,6 +52,7 @@ def search_phases(
     max_phases: int = 5,
     wavelength: Literal["Cu", "Co", "Cr", "Fe", "Mo"] | float = "Cu",
     instrument_profile: str | Path = "Aeris-fds-Pixcel1d-Medipix3",
+    express_mode: bool = True,
     phase_params: dict[str, ...] | None = None,
     refinement_params: dict[str, ...] | None = None,
     return_search_tree: bool = False,
@@ -69,6 +70,8 @@ def search_phases(
         wavelength: the wavelength of the X-ray. It can be either a float or one of the following strings:
             "Cu", "Co", "Cr", "Fe", "Mo", indicating the material of the X-ray source
         instrument_profile: the name of the instrument, or the path to the instrument configuration file (.geq)
+        express_mode: whether to use express mode. In express mode, the phases will be grouped first before
+            searching, which can significantly speed up the search process.
         phase_params: the parameters for the phase search
         refinement_params: the parameters for the refinement
         return_search_tree: whether to return the search tree. This is mainly used for debugging purposes.
@@ -94,6 +97,7 @@ def search_phases(
         phase_params=phase_params,
         wavelength=wavelength,
         instrument_profile=instrument_profile,
+        express_mode=express_mode,
         max_phases=max_phases,
         rpb_threshold=rpb_threshold,
         record_peak_matcher_scores=record_peak_matcher_scores,


### PR DESCRIPTION
Introduce express_mode to reduce computing time.

In express mode, the phases are grouped first and only the top phases will be sent to phase search routine. In the end, the grouped phases are expanded again and shown as "alternative" like a normal mode search.

This significantly reduces the number of refinement required. Our estimation is only 30% computation time required for one pattern.