### PR TITLE
Setting working dir in ray init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .vscode/
 .idea/
 node_modules/
+__MACOSX/
 
 # C extensions
 *.so

--- a/src/dara/jobs.py
+++ b/src/dara/jobs.py
@@ -143,7 +143,7 @@ class PhaseSearchMaker(Maker):
             final_refinement_params: Parameters for the final refinement.
             computed_entries: Computed entries to use for phase prediction.
         """
-        directory = Path(os.getcwd())
+        directory = Path(os.getcwd()).resolve()
 
         if predict_kwargs is None:
             predict_kwargs = {}

--- a/src/dara/search/core.py
+++ b/src/dara/search/core.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import os
 from collections import deque
 from traceback import print_exc
 from typing import TYPE_CHECKING, Literal
@@ -86,6 +85,9 @@ def search_phases(
     if refinement_params is None:
         refinement_params = {}
 
+    if not ray.is_initialized():
+        ray.init(runtime_env={"working_dir": None})
+
     phase_params = {**DEFAULT_PHASE_PARAMS, **phase_params}
     refinement_params = {**DEFAULT_REFINEMENT_PARAMS, **refinement_params}
 
@@ -103,9 +105,6 @@ def search_phases(
         rpb_threshold=rpb_threshold,
         record_peak_matcher_scores=record_peak_matcher_scores,
     )
-
-    if not ray.is_initialized():
-        ray.init(runtime_env={"working_dir": os.getcwd()})
 
     max_worker = ray.cluster_resources()["CPU"]
     pending = [remote_expand_node(search_tree, search_tree.root)]

--- a/src/dara/search/tree.py
+++ b/src/dara/search/tree.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import warnings
 from itertools import zip_longest
 from numbers import Number


### PR DESCRIPTION
This pull request is inherited from pull request #20 to handle issue #19.

We fixed a few code formats to make it pass the ruff check.

Also, the position of ray.init is slightly adjusted so that `ray.init` will not be called accidentally when importing dara module. 

@jrneilson has tested it against dara server.
@idocx has tested it against dara CLI.

