### PR TITLE
Custom BGMN params

### DIFF
--- a/.github/workflows/build_sphinx.yaml
+++ b/.github/workflows/build_sphinx.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Update pip

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/notebooks/automated_refinement.ipynb
+++ b/notebooks/automated_refinement.ipynb
@@ -57,8 +57,8 @@
       "Requirement already satisfied: pure-eval in /Users/yuxing/.pyenv/versions/3.9.16/envs/bgmn/lib/python3.9/site-packages (from stack-data->ipython>=6.1.0->ipywidgets) (0.2.2)\n",
       "Requirement already satisfied: six>=1.12.0 in /Users/yuxing/.pyenv/versions/3.9.16/envs/bgmn/lib/python3.9/site-packages (from asttokens>=2.1.0->stack-data->ipython>=6.1.0->ipywidgets) (1.16.0)\n",
       "\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m23.3.2\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m24.1.1\u001B[0m\n",
-      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.3.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
@@ -135897,24 +135897,20 @@
     "## Refining with customized phase parameters\n",
     "The refinement with default setting looks good. But can it be better?\n",
     "\n",
-    "Dara supports the basic refinement parameters in BGMN / Profex. You can adjust the refinement parameters by passing the parameters to the `do_refinement_no_saving` function."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ed21171",
-   "metadata": {},
-   "source": [
+    "In BGMN, peak profiles are modeled by deconvoluting the instrumental profile from the sample's real structure profile. The sample's broadening is handled using a combination of Lorentzian and Gaussian-like functions.\n",
+    "\n",
+    "Dara supports the basic refinement parameters in BGMN / Profex. You can adjust the refinement parameters by passing the parameters to the `do_refinement_no_saving` function.\n",
+    "\n",
     "Common parameters include:\n",
-    "- `lattice_range`: you can (and need to) specify the range that the lattice parameters can vary. Usually, it can be a small range, like 0.01 ~ 0.05. It is applied to all lattice parameters (a, b, c, alpha, beta, gamma).\n",
-    "- `b1`: controls the width of the peak. `b1` describes the average particle size in the\n",
-    "  XRD sample. The larger the `b1`, the broader the peak. Usually, it is constraint to a\n",
-    "  small range, like from 0 to 0.005. If the fitted  `b1` is too large, you will see the peaks\n",
-    "  go too broad. In this case, your simulated pattern will look like an amorphous\n",
-    "  material that can be easily fit into the background.\n",
-    "- `k1`: also controls the width of the peak. `k1` describes the width of the particle size distribution in the sample. The larger the `k1`, the smaller the distribution is. Usually, it can be constrained to 0 ~ 1.\n",
-    "- `k2`: describes the microstrain in the sample. The larger the `k2`, the larger the microstrain. Usually, it can be a fixed value, like 0.\n",
-    "- `gewicht`: means \"weight\" in German. it contains the information of scale factor. However, in BGMN, it can also be used to specify the preferred orientation you would like to use in the refinement. By specifying the preferred orientation, you can vary the intensity of a set of reflections in the pattern, which can help you fit your pattern better. BGMN is able to decide which reflection to adjust automatically. You only need to specify how strong the preferred orientation is. Usually, it can be `SPHAR0` (none), `SPHAR2` (two preferred orientation parameters), or `SPHAR4` (four preferred orientation parameters), ... (up to `SPHAR10`). The larger the `gewicht`, the stronger the preferred orientation is. But it can cause overfitting as well."
+    "- `lattice_range`: you can (and need to) specify the range that the lattice parameters can vary. Usually, it can be a small range, like 0.01 ~ 0.03. By default it is applied symmetrically to all lattice parameters (a, b, c, alpha, beta, gamma), but it accepts several forms:\n",
+    "    - a single float `r`: a symmetric range `[a*(1-r), a*(1+r)]` applied to all parameters.\n",
+    "    - the string `\"fixed\"`: all lattice parameters are held fixed and not refined.\n",
+    "    - a tuple `(lo, hi)`: explicit fractional deltas giving bounds `[a*(1+lo), a*(1+hi)]`, which lets you build asymmetric or one-sided windows. The range can span both signs (e.g. `(-0.05, 0.2)`), allow only positive deltas / expansion (e.g. `(0.02, 0.1)`), or only negative deltas / contraction (e.g. `(-0.1, 0.0)`). If the starting value falls outside the window, it is clamped to the nearest bound.\n",
+    "    - a dict mapping parameter names (`\"A\"`, `\"B\"`, `\"C\"`, `\"ALPHA\"`, `\"BETA\"`, `\"GAMMA\"`, case-insensitive) to any of the above, for per-parameter control. Use the wildcard key `\"*\"` as a fallback for unlisted parameters; without it, unlisted parameters default to a symmetric `0.1`. For example, `{\"C\": \"fixed\", \"A\": (-0.05, 0.2), \"*\": 0.1}`.\n",
+    "- `b1` (Lorentzian Size Broadening): controls the Lorentian broadening of the peak. Physically, it accounts for the broadening caused by the average crystallite (domain) size. A larger `b1` creates a broader Lorentzian profile with heavy tails, indicating smaller average crystallites. Usually, it is constrained to a small range, such as 0 to 0.005. If the fitted `b1` is too large, you will see the peaks go too broad. In this case, your simulated pattern will look like an amorphous material that can be easily fit into the background.\n",
+    "- `k1` (Gaussian Size Broadening): This defines the Gaussian-like contribution to the size effects. Physically, it acts as a measure of the width of the crystallite size distribution. The larger the `k1`, the smaller the distribution is. Usually, it can be constrained to 0 ~ 1.\n",
+    "- `k2` (Gaussian Strain Broadening): describes the microstrain in the sample. This parameter defines the Gaussian-like broadening caused by microstrain (the mean squared strain in the crystal lattice). A larger `k2` indicates higher internal strain in your sample. Usually, it can be a fixed value, like 0.\n",
+    "- `gewicht`: means \"weight\" in German. It contains the information of scale factor. However, in BGMN, it can also be used to specify the preferred orientation you would like to use in the refinement. By specifying the preferred orientation, you can vary the intensity of a set of reflections in the pattern, which can help you fit your pattern better. BGMN is able to decide which reflection to adjust automatically. You only need to specify how strong the preferred orientation is. Usually, it can be `SPHAR0` (none), `SPHAR2` (two preferred orientation parameters), or `SPHAR4` (four preferred orientation parameters), ... (up to `SPHAR10`). The larger the order, the stronger the preferred orientation is. But it can cause overfitting as well."
    ]
   },
   {
@@ -135926,18 +135922,10 @@
     "In Dara, all the phase parameters are passed as a dictionary arg called `phase_params`. The key is the parameter name, and the value is the parameter value. Dara supports three types of values:\n",
     "\n",
     "- `fixed`. This is a string. The parameter will be fixed to the default value (usually 0).\n",
-    "- `(initial value)_(min value)^(max value)`. This is a string. The parameter will be\n",
-    "  allowed to vary in the refinement between initial value to the min value to the max value. The min value begins with\n",
-    "  `_`, and the max value begins with `^`.\n",
-    "- Other values. It can be a string or a number. For example, setting `gewicht` to\n",
-    "  `SPHAR2` means that preferred orientation is modeled with the `SPHAR2` settings; setting `lattice_range` to\n",
-    "  0.05 means that the lattice parameters can vary up to 5%.. See the BGMN / Profex\n",
-    "  manual for more information on these settings.\n",
+    "- `(initial value)_(min value)^(max value)`. This is a string. The parameter will be allowed to vary in the refinement between the initial value, the min value, and the max value. The min value begins with `_`, and the max value begins with `^`.\n",
+    "- Other values. It can be a string or a number. For example, setting `gewicht` to `SPHAR2` means that preferred orientation is modeled with the `SPHAR2` settings; setting `lattice_range` to 0.05 means that the lattice parameters can vary up to 5%. See the BGMN / Profex manual for more information on these settings.\n",
     "\n",
-    "If you want to allow 5% variation in lattice parameters, then use the following\n",
-    "settings. `b1`: (started from 0, min = 0, max = 0.005), `k1`: (started from 0, min = 0,\n",
-    "max = 1), `k2`: fixed to 0, and `gewicht`: `SPHAR2`. This corresponds to a\n",
-    "`phase_params` dict of:"
+    "If you want to allow 5% variation in lattice parameters, then use the following settings. `b1`: (started from 0, min = 0, max = 0.005), `k1`: (started from 0, min = 0, max = 1), `k2`: fixed to 0, and `gewicht`: `SPHAR2`. This corresponds to a `phase_params` dict of:"
    ]
   },
   {
@@ -271309,11 +271297,45 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e98ac887",
+   "metadata": {},
+   "source": [
+    "#### Advanced: custom parameters\n",
+    "For cases where the standard parameters above aren't enough, e.g. the refinement of high-temperature measurements acquired during in-situ XRD, the code supports two optional arguments that let you inject your own BGMN definitions: `custom_params` and `custom_params_map`.\n",
+    "\n",
+    "- `custom_params`: an optional list of raw BGMN string lines, for defining global parameters or equations you can reference elsewhere, e.g. `\"PARAM=Bglobal=0.05_0.01^0.20 //\"`.\n",
+    "- `custom_params_map`: an optional dictionary mapping element symbols to per-site parameters to add or overwrite, e.g. `TDS` for thermal displacement and `Occ` for occupancy. Use the wildcard key `\"*\"` to apply parameters to every element not otherwise matched.\n",
+    "\n",
+    "See the BGMN / Profex manual for more details on these settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea046ec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_params = [\n",
+    "    \"PARAM=Bglobal=0.05_0.01^0.20 //\",\n",
+    "    \"PARAM=BO=0.1_0.02^0.3 //\",\n",
+    "    \"PARAM=BCo=0.1_0.02^0.3 //\",\n",
+    "]\n",
+    "\n",
+    "custom_params_map = {\n",
+    "    \"*\": {\"TDS\": \"Bglobal\"},\n",
+    "    \"O\": {\"TDS\": \"BO\", \"Occ\": \"OccO\"},\n",
+    "    \"Co\": {\"TDS\": \"BCo\"},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5f2163cb",
    "metadata": {},
    "source": [
     "#### Specify different parameters for different phases\n",
-    "In the previous example, the refinement option is applied to all phases. But you can also specify different parameters for different phases. To do so, you will need to pass a special `RefinementPhase` object to the `phases` parameter."
+    "In the previous example, the refinement option is applied to all phases. But you can also specify different parameters for different phases. To do so, you will need to pass a special `RefinementPhase` object to the `phases` parameter. Any of the parameters defined above can be specified differently for one or more indiviudal phases."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ ignore = [
     "C408", # unnecessary-collection-call
     "D", # Missing docstring in magic method
     "PD011", # pandas-use-of-dot-values
-    "PD901", # pandas-df-variable-name
     "PERF203", # try-except-in-loop
     "PERF401", # manual-list-comprehension (TODO fix these or wait for autofix)
     "PLC0415", # `import` should be at the top of the file

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -267,6 +267,8 @@ def cif2str(
     k2: str = "0_0^0.01",
     b1: str = "0_0^0.01",
     lebail: bool = False,
+    custom_lines: list[str] | None = None,
+    element_params_map: dict[str, str] | None = None,
 ) -> Path:
     """
     Convert CIF to Str format.
@@ -283,8 +285,16 @@ def cif2str(
         k2: the second peak parameter to be refined. Read more in the BGMN manual.
         b1: the third peak parameter to be refined. Read more in the BGMN manual.
         lebail: whether to use the Le Bail method
+        custom_lines: optional list of custom BGMN string parameters to inject. This allows for defining complex 
+            mathematical equations, global parameters, or fractional occupancies 
+            (e.g., ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]).
+        element_params_map: optional dictionary mapping element symbols to custom variable strings. You can inject
+            multiple BGMN keywords into the Wyckoff line simultaneously. 
+            You can use the wildcard key "*" to apply a global parameter to all elements that are not specifically 
+            matched in the dictionary (e.g., {"*": "Bglobal", "O": "BO Occ=OccO"}).
 
-    An example of the output .str file:
+    An example of the output .str file when using custom_lines=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"] 
+    and element_params_map={"*": "Bglobal", "O": "BO"}:
 
     PHASE=BariumzirconiumtinIVoxide105053 // ICSD_43137
     Reference=ICSD_43137 //
@@ -293,9 +303,11 @@ def cif2str(
     PARAM=A=0.416280_0.412117^0.420443 //
     RP=4 k1=0 k2=0 PARAM=B1=0_0^0.01 GEWICHT=SPHAR4 //
     GOAL:BariumzirconiumtinIVoxide105053=GEWICHT*ifthenelse(ifdef(d),exp(my*d*3/4),1) //
-    E=BA+2 Wyckoff=b x=0.500000 y=0.500000 z=0.500000 TDS=0.010000
-    E=(ZR+4(0.5000),SN+4(0.5000)) Wyckoff=a x=0.000000 y=0.000000 z=0.000000 TDS=0.010000
-    E=O-2 Wyckoff=d x=0.500000 y=0.000000 z=0.000000 TDS=0.010000
+    PARAM=Bglobal=0.05_0.01^0.20 //
+    PARAM=BO=0.1_0.02^0.3 //
+    E=BA+2 Wyckoff=b x=0.500000 y=0.500000 z=0.500000 TDS=Bglobal
+    E=(ZR+4(0.5000),SN+4(0.5000)) Wyckoff=a x=0.000000 y=0.000000 z=0.000000 TDS=Bglobal
+    E=O-2 Wyckoff=d x=0.500000 y=0.000000 z=0.000000 TDS=BO
 
     """
     str_path = (
@@ -365,11 +377,38 @@ def cif2str(
     # add goals
     str_text += f"GOAL:{phase_name}=GEWICHT*ifthenelse(ifdef(d),exp(my*d*3/4),1) //\nGOAL=GrainSize(1,1,1) //\n"
 
-    # add wyckoff positions
-    element_settings_str = [
-        " ".join([f"{k}={v}" for k, v in element_setting.items()])
-        for element_setting in element_settings
-    ]
+    # add custom lines injected from python dict
+    if custom_lines is not None:
+        for line in custom_lines:
+            str_text += f"{line}\n"
+
+    if element_params_map is None:
+        element_params_map = {}
+
+    # add wyckoff positions and overwrite TDS if mapped
+    element_settings_str = []
+    for element_setting in element_settings:
+        element_name = element_setting.get("E", "")
+        
+        assigned_val = None
+        
+        # First, check if there is a specific match for this element
+        for element_key, custom_val in element_params_map.items():
+            if element_key != "*" and element_key in element_name:
+                assigned_val = custom_val
+                break
+                
+        # If no specific match was found, check if a wildcard was provided
+        if assigned_val is None and "*" in element_params_map:
+            assigned_val = element_params_map["*"]
+            
+        # If we found either a specific match or a wildcard, overwrite the TDS
+        if assigned_val is not None:
+            element_setting["TDS"] = assigned_val
+
+        line_str = " ".join([f"{k}={v}" for k, v in element_setting.items()])
+        element_settings_str.append(line_str)
+
     str_text += "\n".join(element_settings_str)
 
     with open(str_path, "w") as f:

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -285,16 +285,16 @@ def cif2str(
         k2: the second peak parameter to be refined. Read more in the BGMN manual.
         b1: the third peak parameter to be refined. Read more in the BGMN manual.
         lebail: whether to use the Le Bail method
-        custom_lines: optional list of custom BGMN string parameters to inject. This allows for defining complex
+        custom_params: optional list of custom BGMN string parameters to inject. This allows for defining complex
             mathematical equations, global parameters, or fractional occupancies
             (e.g., ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]).
-        element_params_map: optional dictionary mapping element symbols to dictionaries of parameters to add
+        custom_params_map: optional dictionary mapping element symbols to dictionaries of parameters to add
             or overwrite. You can use the wildcard key "*" to apply parameters to all elements that are not
             specifically matched in the dictionary (e.g., {"*": {"TDS": "Bglobal"}, "O": {"TDS": "BO", "Occ": "OccO"}}).
 
     An example of the output .str file when using
-    custom_lines=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
-    and element_params_map={"*": {"TDS": "Bglobal"}, "O": {"TDS": "BO", "Occ": "OccO"}}:
+    custom_params=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
+    and custom_params_map={"*": {"TDS": "Bglobal"}, "O": {"TDS": "BO", "Occ": "OccO"}}:
 
     PHASE=BariumzirconiumtinIVoxide105053 // ICSD_43137
     Reference=ICSD_43137 //
@@ -377,13 +377,13 @@ def cif2str(
     # add goals
     str_text += f"GOAL:{phase_name}=GEWICHT*ifthenelse(ifdef(d),exp(my*d*3/4),1) //\nGOAL=GrainSize(1,1,1) //\n"
 
-    # add custom lines injected from python dict
-    if custom_lines is not None:
-        for line in custom_lines:
+    # add custom params injected from python dict
+    if custom_params is not None:
+        for line in custom_params:
             str_text += f"{line}\n"
 
-    if element_params_map is None:
-        element_params_map = {}
+    if custom_params_map is None:
+        custom_params_map = {}
 
     # add wyckoff positions and overwrite parameters if mapped
     element_settings_str = []
@@ -393,14 +393,14 @@ def cif2str(
         assigned_dict = None
 
         # First, check if there is a specific match for this element
-        for element_key, custom_dict in element_params_map.items():
+        for element_key, custom_dict in custom_params_map.items():
             if element_key != "*" and element_key in element_name:
                 assigned_dict = custom_dict
                 break
 
         # If no specific match was found, check if a wildcard was provided
-        if assigned_dict is None and "*" in element_params_map:
-            assigned_dict = element_params_map["*"]
+        if assigned_dict is None and "*" in custom_params_map:
+            assigned_dict = custom_params_map["*"]
 
         # If we found either a specific match or a wildcard, update the dictionary
         if assigned_dict is not None:

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -285,15 +285,16 @@ def cif2str(
         k2: the second peak parameter to be refined. Read more in the BGMN manual.
         b1: the third peak parameter to be refined. Read more in the BGMN manual.
         lebail: whether to use the Le Bail method
-        custom_lines: optional list of custom BGMN string parameters to inject. This allows for defining complex 
-            mathematical equations, global parameters, or fractional occupancies 
+        custom_lines: optional list of custom BGMN string parameters to inject. This allows for defining complex
+            mathematical equations, global parameters, or fractional occupancies
             (e.g., ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]).
         element_params_map: optional dictionary mapping element symbols to custom variable strings. You can inject
-            multiple BGMN keywords into the Wyckoff line simultaneously. 
-            You can use the wildcard key "*" to apply a global parameter to all elements that are not specifically 
-            matched in the dictionary (e.g., {"*": "Bglobal", "O": "BO Occ=OccO"}).
+            multiple BGMN keywords into the Wyckoff line simultaneously. You can use the wildcard key "*" to apply
+            a global parameter to all elements that are not specifically matched in the dictionary
+            (e.g., {"*": "Bglobal", "O": "BO Occ=OccO"}).
 
-    An example of the output .str file when using custom_lines=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"] 
+    An example of the output .str file when using
+    custom_lines=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
     and element_params_map={"*": "Bglobal", "O": "BO"}:
 
     PHASE=BariumzirconiumtinIVoxide105053 // ICSD_43137
@@ -389,19 +390,19 @@ def cif2str(
     element_settings_str = []
     for element_setting in element_settings:
         element_name = element_setting.get("E", "")
-        
+
         assigned_val = None
-        
+
         # First, check if there is a specific match for this element
         for element_key, custom_val in element_params_map.items():
             if element_key != "*" and element_key in element_name:
                 assigned_val = custom_val
                 break
-                
+
         # If no specific match was found, check if a wildcard was provided
         if assigned_val is None and "*" in element_params_map:
             assigned_val = element_params_map["*"]
-            
+
         # If we found either a specific match or a wildcard, overwrite the TDS
         if assigned_val is not None:
             element_setting["TDS"] = assigned_val

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -267,8 +267,8 @@ def cif2str(
     k2: str = "0_0^0.01",
     b1: str = "0_0^0.01",
     lebail: bool = False,
-    custom_lines: list[str] | None = None,
-    element_params_map: dict[str, dict] | None = None,
+    custom_params: list[str] | None = None,
+    custom_params_map: dict[str, dict] | None = None,
 ) -> Path:
     """
     Convert CIF to Str format.

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -268,7 +268,7 @@ def cif2str(
     b1: str = "0_0^0.01",
     lebail: bool = False,
     custom_lines: list[str] | None = None,
-    element_params_map: dict[str, str] | None = None,
+    element_params_map: dict[str, dict] | None = None,
 ) -> Path:
     """
     Convert CIF to Str format.
@@ -288,14 +288,13 @@ def cif2str(
         custom_lines: optional list of custom BGMN string parameters to inject. This allows for defining complex
             mathematical equations, global parameters, or fractional occupancies
             (e.g., ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]).
-        element_params_map: optional dictionary mapping element symbols to custom variable strings. You can inject
-            multiple BGMN keywords into the Wyckoff line simultaneously. You can use the wildcard key "*" to apply
-            a global parameter to all elements that are not specifically matched in the dictionary
-            (e.g., {"*": "Bglobal", "O": "BO Occ=OccO"}).
+        element_params_map: optional dictionary mapping element symbols to dictionaries of parameters to add
+            or overwrite. You can use the wildcard key "*" to apply parameters to all elements that are not
+            specifically matched in the dictionary (e.g., {"*": {"TDS": "Bglobal"}, "O": {"TDS": "BO", "Occ": "OccO"}}).
 
     An example of the output .str file when using
     custom_lines=["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
-    and element_params_map={"*": "Bglobal", "O": "BO"}:
+    and element_params_map={"*": {"TDS": "Bglobal"}, "O": {"TDS": "BO", "Occ": "OccO"}}:
 
     PHASE=BariumzirconiumtinIVoxide105053 // ICSD_43137
     Reference=ICSD_43137 //
@@ -308,7 +307,7 @@ def cif2str(
     PARAM=BO=0.1_0.02^0.3 //
     E=BA+2 Wyckoff=b x=0.500000 y=0.500000 z=0.500000 TDS=Bglobal
     E=(ZR+4(0.5000),SN+4(0.5000)) Wyckoff=a x=0.000000 y=0.000000 z=0.000000 TDS=Bglobal
-    E=O-2 Wyckoff=d x=0.500000 y=0.000000 z=0.000000 TDS=BO
+    E=O-2 Wyckoff=d x=0.500000 y=0.000000 z=0.000000 TDS=BO Occ=OccO
 
     """
     str_path = (
@@ -386,26 +385,26 @@ def cif2str(
     if element_params_map is None:
         element_params_map = {}
 
-    # add wyckoff positions and overwrite TDS if mapped
+    # add wyckoff positions and overwrite parameters if mapped
     element_settings_str = []
     for element_setting in element_settings:
         element_name = element_setting.get("E", "")
 
-        assigned_val = None
+        assigned_dict = None
 
         # First, check if there is a specific match for this element
-        for element_key, custom_val in element_params_map.items():
+        for element_key, custom_dict in element_params_map.items():
             if element_key != "*" and element_key in element_name:
-                assigned_val = custom_val
+                assigned_dict = custom_dict
                 break
 
         # If no specific match was found, check if a wildcard was provided
-        if assigned_val is None and "*" in element_params_map:
-            assigned_val = element_params_map["*"]
+        if assigned_dict is None and "*" in element_params_map:
+            assigned_dict = element_params_map["*"]
 
-        # If we found either a specific match or a wildcard, overwrite the TDS
-        if assigned_val is not None:
-            element_setting["TDS"] = assigned_val
+        # If we found either a specific match or a wildcard, update the dictionary
+        if assigned_dict is not None:
+            element_setting.update(assigned_dict)
 
         line_str = " ".join([f"{k}={v}" for k, v in element_setting.items()])
         element_settings_str.append(line_str)

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -221,9 +221,21 @@ def make_spacegroup_setting_str(spacegroup_setting: dict[str, Any]) -> str:
 def make_lattice_parameters_str(
     spacegroup_setting: dict[str, Any],
     structure: SymmetrizedStructure,
-    lattice_range: float | Literal["fixed"],
+    lattice_range: float | tuple[float, float] | Literal["fixed"],
 ) -> str:
-    """Make the lattice parameters string."""
+    """Make the lattice parameters string.
+
+    Args:
+        spacegroup_setting: the spacegroup setting dict.
+        structure: the symmetrized structure.
+        lattice_range: controls the refinement bounds for lattice parameters:
+            - "fixed": parameters are not refined.
+            - float `r`: symmetric fractional range, i.e. bounds are
+              `[v * (1 - r), v * (1 + r)]`.
+            - tuple `(lo, hi)`: explicit fractional deltas, bounds are
+              `[v * (1 + lo), v * (1 + hi)]`. Use e.g. `(0.0, 0.1)` to allow
+              only positive deviation, or `(-0.1, 0.0)` for only negative.
+    """
     crystal_system = spacegroup_setting["setting"]["Lattice"]
     lattice_parameters = get_lattice_parameters_from_lattice(
         structure.lattice, crystal_system
@@ -234,9 +246,18 @@ def make_lattice_parameters_str(
             [f"{k}={v:.5f}" for k, v in lattice_parameters.items()]
         )
     else:
+        if isinstance(lattice_range, (int, float)):
+            lo, hi = -float(lattice_range), float(lattice_range)
+        else:
+            lo, hi = float(lattice_range[0]), float(lattice_range[1])
+            if lo > hi:
+                raise ValueError(
+                    f"lattice_range lower bound ({lo}) must be <= upper bound ({hi})"
+                )
+
         lattice_parameters_str = " ".join(
             [
-                f"PARAM={k}={v:.5f}_{v * (1 - lattice_range):.5f}^{v * (1 + lattice_range):.5f}"
+                f"PARAM={k}={v:.5f}_{v * (1 + lo):.5f}^{v * (1 + hi):.5f}"
                 for k, v in lattice_parameters.items()
             ]
         )
@@ -260,7 +281,7 @@ def cif2str(
     phase_name_suffix: str = "",
     working_dir: Path | None = None,
     *,
-    lattice_range: float = 0.1,
+    lattice_range: float | tuple[float, float] = 0.1,
     gewicht: str = "0_0",
     rp: int = 4,
     k1: str = "0_0^0.01",
@@ -277,7 +298,14 @@ def cif2str(
         cif_path: the path to the CIF file
         phase_name_suffix: the suffix of the phase name
         working_dir: the folder to hold the processed str file
-        lattice_range: the range of the lattice parameters to be refined
+        lattice_range: the range of the lattice parameters to be refined. Can be:
+            - a single float `r` (default behavior): symmetric range `[a - r*a, a + r*a]`
+            - a tuple `(lo, hi)`: explicit fractional deltas, allowing asymmetric or
+              one-sided ranges. For example:
+                * `(-0.1, 0.1)` is equivalent to `0.1` (symmetric)
+                * `(0.0, 0.1)` confines refinement to only positive deviations
+                * `(-0.1, 0.0)` confines refinement to only negative deviations
+                * `(-0.05, 0.2)` allows asymmetric refinement
         gewicht: the weight fraction of the phase to be refined. Options: 0_0, SPHAR0, and SPHAR2. If 0_0, then no
             preferred orientation. Read more in the BGMN manual.
         rp: the peak function to be used in the refinement. Read more in the BGMN manual.
@@ -359,10 +387,22 @@ def cif2str(
     # add spacegroup setting
     str_text += make_spacegroup_setting_str(spacegroup_setting) + "\n"
 
+    # normalize lattice_range to a (lo, hi) tuple of fractional deltas
+    if isinstance(lattice_range, (int, float)):
+        lattice_bounds = (-float(lattice_range), float(lattice_range))
+    else:
+        lo, hi = lattice_range
+        lo, hi = float(lo), float(hi)
+        if lo > hi:
+            raise ValueError(
+                f"lattice_range lower bound ({lo}) must be <= upper bound ({hi})"
+            )
+        lattice_bounds = (lo, hi)
+
     # add lattice
     str_text += (
         make_lattice_parameters_str(
-            spacegroup_setting, structure, lattice_range=lattice_range
+            spacegroup_setting, structure, lattice_range=lattice_bounds
         )
         + "\n"
     )

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -235,6 +235,10 @@ def make_lattice_parameters_str(
             - tuple `(lo, hi)`: explicit fractional deltas, bounds are
               `[v * (1 + lo), v * (1 + hi)]`. Use e.g. `(0.0, 0.1)` to allow
               only positive deviation, or `(-0.1, 0.0)` for only negative.
+              If the unmodified value `v` falls outside the resulting window
+              (e.g. both deltas positive or both negative), the starting value
+              is clamped to the boundary closest to `v` (i.e. nearest 0%
+              deviation), so BGMN always receives a valid `lo <= start <= hi`.
     """
     crystal_system = spacegroup_setting["setting"]["Lattice"]
     lattice_parameters = get_lattice_parameters_from_lattice(
@@ -255,12 +259,18 @@ def make_lattice_parameters_str(
                     f"lattice_range lower bound ({lo}) must be <= upper bound ({hi})"
                 )
 
-        lattice_parameters_str = " ".join(
-            [
-                f"PARAM={k}={v:.5f}_{v * (1 + lo):.5f}^{v * (1 + hi):.5f}"
-                for k, v in lattice_parameters.items()
-            ]
-        )
+        parts = []
+        for k, v in lattice_parameters.items():
+            lo_bound = v * (1 + lo)
+            hi_bound = v * (1 + hi)
+            # clamp the starting value into [lo_bound, hi_bound]; this picks
+            # the endpoint closest to the unmodified v (i.e. nearest 0% deviation)
+            start = min(max(v, lo_bound), hi_bound)
+            parts.append(
+                f"PARAM={k}={start:.5f}_{lo_bound:.5f}^{hi_bound:.5f}"
+            )
+        lattice_parameters_str = " ".join(parts)
+
     lattice_parameters_str += " //"
     return lattice_parameters_str
 

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -318,12 +318,12 @@ _NUMERIC_GEWICHT_RE = re.compile(
 
 def make_peak_parameter_str(k1: str, k2: str, b1: str, gewicht: str, rp: int) -> str:
     """Make the peak parameter string."""
-    if _NUMERIC_GEWICHT_RE.match(gewicht):
-        # numeric refinable spec, e.g. "0_0", "0.01_0.001^0.1"
-        gewicht_part = f"PARAM=GEWICHT={gewicht} //"
-    else:
-        # symbolic, e.g. "SPHAR0", "SPHAR2", "SPHAR4", "fixed"
-        gewicht_part = f"GEWICHT={gewicht} //"
+    # Numeric specs are refinable; symbolic specs are emitted as fixed names.
+    gewicht_part = (
+        f"PARAM=GEWICHT={gewicht} //"
+        if _NUMERIC_GEWICHT_RE.match(gewicht)
+        else f"GEWICHT={gewicht} //"
+    )
 
     return (
         f"RP={rp} "

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -275,14 +275,26 @@ def make_lattice_parameters_str(
     return lattice_parameters_str
 
 
+
+_NUMERIC_GEWICHT_RE = re.compile(
+    r"^-?\d+(?:\.\d+)?_-?\d+(?:\.\d+)?(?:\^-?\d+(?:\.\d+)?)?$"
+)
+
 def make_peak_parameter_str(k1: str, k2: str, b1: str, gewicht: str, rp: int) -> str:
     """Make the peak parameter string."""
+    if _NUMERIC_GEWICHT_RE.match(gewicht):
+        # numeric refinable spec, e.g. "0_0", "0.01_0.001^0.1"
+        gewicht_part = f"PARAM=GEWICHT={gewicht} //"
+    else:
+        # symbolic, e.g. "SPHAR0", "SPHAR2", "SPHAR4", "fixed"
+        gewicht_part = f"GEWICHT={gewicht} //"
+
     return (
         f"RP={rp} "
         + (f"PARAM=k1={k1} " if k1 != "fixed" else "k1=0 ")
         + (f"PARAM=k2={k2} " if k2 != "fixed" else "k2=0 ")
         + (f"PARAM=B1={b1} " if b1 != "fixed" else "B1=0 ")
-        + (f"GEWICHT={gewicht} //" if gewicht != "0_0" else "PARAM=GEWICHT=0_0 //")
+        + gewicht_part
     )
 
 

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -410,7 +410,9 @@ def cif2str(
     str_text += make_spacegroup_setting_str(spacegroup_setting) + "\n"
 
     # normalize lattice_range to a (lo, hi) tuple of fractional deltas
-    if isinstance(lattice_range, (int, float)):
+    if lattice_range == "fixed":
+        lattice_bounds = "fixed"
+    elif isinstance(lattice_range, (int, float)):
         lattice_bounds = (-float(lattice_range), float(lattice_range))
     else:
         lo, hi = lattice_range

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -394,9 +394,12 @@ def cif2str(
 
         # First, check if there is a specific match for this element
         for element_key, custom_dict in custom_params_map.items():
-            if element_key != "*" and element_key in element_name:
-                assigned_dict = custom_dict
-                break
+            if element_key != "*":
+                # Use regex with word boundaries to prevent partial matches
+                # e.g., ensures "O" doesn't match the "O" in "CO" (Cobalt)
+                if re.search(rf"\b{element_key}\b", element_name, re.IGNORECASE):
+                    assigned_dict = custom_dict
+                    break
 
         # If no specific match was found, check if a wildcard was provided
         if assigned_dict is None and "*" in custom_params_map:

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -26,10 +26,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
 
+LatticeSpec = Literal["fixed"] | float | int | tuple[float, float]
+LatticeRange = LatticeSpec | dict[str, LatticeSpec]
 
 class CIF2StrError(Exception):
     """CIF2Str error."""
 
+def _normalize_lattice_spec(spec: Any, *, label: str) -> Literal["fixed"] | tuple[float, float]:
+    """Normalize a single lattice spec into 'fixed' or (lo, hi) fractional deltas."""
+    if spec == "fixed":
+        return "fixed"
+    if isinstance(spec, (int, float)):
+        return (-float(spec), float(spec))
+    try:
+        lo, hi = spec
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Invalid lattice spec for {label!r}: {spec!r}. "
+            f"Expected 'fixed', a number, or a (lo, hi) tuple."
+        )
+    lo, hi = float(lo), float(hi)
+    if lo > hi:
+        raise ValueError(
+            f"lattice_range lower bound ({lo}) must be <= upper bound ({hi}) for {label!r}"
+        )
+    return (lo, hi)
 
 def process_specie_string(sp: str | Specie | Element | DummySpecie) -> str:
     """Reverse the charge notation of a species."""
@@ -221,58 +242,73 @@ def make_spacegroup_setting_str(spacegroup_setting: dict[str, Any]) -> str:
 def make_lattice_parameters_str(
     spacegroup_setting: dict[str, Any],
     structure: SymmetrizedStructure,
-    lattice_range: float | tuple[float, float] | Literal["fixed"],
+    lattice_range: LatticeRange,
 ) -> str:
     """Make the lattice parameters string.
 
     Args:
         spacegroup_setting: the spacegroup setting dict.
         structure: the symmetrized structure.
-        lattice_range: controls the refinement bounds for lattice parameters:
-            - "fixed": parameters are not refined.
-            - float `r`: symmetric fractional range, i.e. bounds are
-              `[v * (1 - r), v * (1 + r)]`.
-            - tuple `(lo, hi)`: explicit fractional deltas, bounds are
-              `[v * (1 + lo), v * (1 + hi)]`. Use e.g. `(0.0, 0.1)` to allow
-              only positive deviation, or `(-0.1, 0.0)` for only negative.
-              If the unmodified value `v` falls outside the resulting window
-              (e.g. both deltas positive or both negative), the starting value
-              is clamped to the boundary closest to `v` (i.e. nearest 0%
-              deviation), so BGMN always receives a valid `lo <= start <= hi`.
+        lattice_range: controls the refinement bounds for lattice parameters. Can be:
+            - "fixed": all parameters are held fixed (not refined).
+            - float `r`: symmetric fractional range for all params, i.e. bounds
+              are `[v * (1 - r), v * (1 + r)]`.
+            - tuple `(lo, hi)`: explicit fractional deltas for all params, bounds
+              are `[v * (1 + lo), v * (1 + hi)]`.
+            - dict mapping parameter name (e.g. "A", "B", "C", "ALPHA", "BETA",
+              "GAMMA", case-insensitive) to any of the above per-parameter specs.
+              Parameters not present in the dict fall back to the value under the
+              "*" key, or to symmetric 0.1 if no "*" key is given.
+
+        For tuple specs, if the unmodified value `v` falls outside the resulting
+        window, the starting value is clamped to the boundary closest to `v`, so
+        BGMN always receives a valid `lo <= start <= hi`.
     """
     crystal_system = spacegroup_setting["setting"]["Lattice"]
     lattice_parameters = get_lattice_parameters_from_lattice(
         structure.lattice, crystal_system
     )
 
-    if lattice_range == "fixed":
-        lattice_parameters_str = " ".join(
-            [f"{k}={v:.5f}" for k, v in lattice_parameters.items()]
-        )
-    else:
-        if isinstance(lattice_range, (int, float)):
-            lo, hi = -float(lattice_range), float(lattice_range)
-        else:
-            lo, hi = float(lattice_range[0]), float(lattice_range[1])
-            if lo > hi:
+    # build a per-parameter resolver
+    if isinstance(lattice_range, dict):
+        # normalize keys to uppercase so users can pass "a", "alpha", etc.
+        norm_range = {}
+        for key, spec in lattice_range.items():
+            norm_key = key if key == "*" else key.upper()
+            if norm_key in norm_range:
                 raise ValueError(
-                    f"lattice_range lower bound ({lo}) must be <= upper bound ({hi})"
+                    f"Duplicate lattice parameter key after normalization: {norm_key!r}"
                 )
+            norm_range[norm_key] = spec
 
-        parts = []
-        for k, v in lattice_parameters.items():
-            lo_bound = v * (1 + lo)
-            hi_bound = v * (1 + hi)
-            # clamp the starting value into [lo_bound, hi_bound]; this picks
-            # the endpoint closest to the unmodified v (i.e. nearest 0% deviation)
-            start = min(max(v, lo_bound), hi_bound)
-            parts.append(
-                f"PARAM={k}={start:.5f}_{lo_bound:.5f}^{hi_bound:.5f}"
-            )
-        lattice_parameters_str = " ".join(parts)
+        default_spec = norm_range.get("*", 0.1)
 
-    lattice_parameters_str += " //"
-    return lattice_parameters_str
+        def resolve(name: str) -> Literal["fixed"] | tuple[float, float]:
+            spec = norm_range.get(name, default_spec)
+            return _normalize_lattice_spec(spec, label=name)
+    else:
+        normalized = _normalize_lattice_spec(lattice_range, label="lattice_range")
+
+        def resolve(name: str) -> Literal["fixed"] | tuple[float, float]:
+            return normalized
+
+    parts = []
+    for k, v in lattice_parameters.items():
+        bounds = resolve(k)
+        if bounds == "fixed":
+            parts.append(f"{k}={v:.5f}")
+        else:
+            lo, hi = bounds
+            if lo == hi:
+                parts.append(f"{k}={v * (1 + lo):.5f}")
+            else:
+                lo_bound = v * (1 + lo)
+                hi_bound = v * (1 + hi)
+                # clamp the starting value into [lo_bound, hi_bound]
+                start = min(max(v, lo_bound), hi_bound)
+                parts.append(f"PARAM={k}={start:.5f}_{lo_bound:.5f}^{hi_bound:.5f}")
+
+    return " ".join(parts) + " //"
 
 
 
@@ -303,7 +339,7 @@ def cif2str(
     phase_name_suffix: str = "",
     working_dir: Path | None = None,
     *,
-    lattice_range: float | tuple[float, float] = 0.1,
+    lattice_range: LatticeRange = 0.1,
     gewicht: str = "0_0",
     rp: int = 4,
     k1: str = "0_0^0.01",
@@ -320,14 +356,23 @@ def cif2str(
         cif_path: the path to the CIF file
         phase_name_suffix: the suffix of the phase name
         working_dir: the folder to hold the processed str file
-        lattice_range: the range of the lattice parameters to be refined. Can be:
+        lattice_range: controls the refinement bounds for the lattice parameters. Can be:
             - a single float `r` (default behavior): symmetric range `[a - r*a, a + r*a]`
+            - the string "fixed": all lattice parameters are held fixed (not refined)
             - a tuple `(lo, hi)`: explicit fractional deltas, allowing asymmetric or
               one-sided ranges. For example:
                 * `(-0.1, 0.1)` is equivalent to `0.1` (symmetric)
                 * `(0.0, 0.1)` confines refinement to only positive deviations
                 * `(-0.1, 0.0)` confines refinement to only negative deviations
                 * `(-0.05, 0.2)` allows asymmetric refinement
+            - a dict mapping a lattice parameter name to any of the above per-parameter
+              specs, for fine-grained per-parameter control. Valid keys are "A", "B",
+              "C", "ALPHA", "BETA", "GAMMA" (case-insensitive). Use the wildcard key "*"
+              to set a fallback for any parameter not explicitly listed; if no "*" key is
+              given, unlisted parameters default to a symmetric 0.1. For example:
+                * `{"C": "fixed", "A": (-0.05, 0.2), "*": 0.1}` fixes C, refines A
+                  asymmetrically, and refines the rest symmetrically at 0.1
+                * `{"A": 0.1, "*": "fixed"}` refines only A and fixes everything else
         gewicht: the weight fraction of the phase to be refined. Options: 0_0, SPHAR0, and SPHAR2. If 0_0, then no
             preferred orientation. Read more in the BGMN manual.
         rp: the peak function to be used in the refinement. Read more in the BGMN manual.
@@ -409,24 +454,10 @@ def cif2str(
     # add spacegroup setting
     str_text += make_spacegroup_setting_str(spacegroup_setting) + "\n"
 
-    # normalize lattice_range to a (lo, hi) tuple of fractional deltas
-    if lattice_range == "fixed":
-        lattice_bounds = "fixed"
-    elif isinstance(lattice_range, (int, float)):
-        lattice_bounds = (-float(lattice_range), float(lattice_range))
-    else:
-        lo, hi = lattice_range
-        lo, hi = float(lo), float(hi)
-        if lo > hi:
-            raise ValueError(
-                f"lattice_range lower bound ({lo}) must be <= upper bound ({hi})"
-            )
-        lattice_bounds = (lo, hi)
-
     # add lattice
     str_text += (
         make_lattice_parameters_str(
-            spacegroup_setting, structure, lattice_range=lattice_bounds
+            spacegroup_setting, structure, lattice_range=lattice_range
         )
         + "\n"
     )

--- a/src/dara/cif2str.py
+++ b/src/dara/cif2str.py
@@ -394,12 +394,11 @@ def cif2str(
 
         # First, check if there is a specific match for this element
         for element_key, custom_dict in custom_params_map.items():
-            if element_key != "*":
-                # Use regex with word boundaries to prevent partial matches
-                # e.g., ensures "O" doesn't match the "O" in "CO" (Cobalt)
-                if re.search(rf"\b{element_key}\b", element_name, re.IGNORECASE):
-                    assigned_dict = custom_dict
-                    break
+            # Use regex with word boundaries to prevent partial matches
+            # e.g., ensures "O" doesn't match the "O" in "CO" (Cobalt)
+            if element_key != "*" and re.search(rf"\b{element_key}\b", element_name, re.IGNORECASE):
+                assigned_dict = custom_dict
+                break
 
         # If no specific match was found, check if a wildcard was provided
         if assigned_dict is None and "*" in custom_params_map:

--- a/src/dara/result.py
+++ b/src/dara/result.py
@@ -215,6 +215,22 @@ class ParseError(Exception):
     """Error when parsing the result."""
 
 
+def _dedupe_phase_names(phase_names: list[str]) -> list[str]:
+    """Return phase names with deterministic suffixes for duplicates.
+
+    Refinement outputs are stored in dict-backed containers in several places
+    (lst/dia/par). Duplicate phase names would overwrite earlier entries, so
+    we disambiguate repeated names as ``name__dupN`` where N starts at 2.
+    """
+    counts: dict[str, int] = {}
+    out: list[str] = []
+    for name in phase_names:
+        counts[name] = counts.get(name, 0) + 1
+        n = counts[name]
+        out.append(name if n == 1 else f"{name}__dup{n}")
+    return out
+
+
 def get_result(control_file: Path) -> RefinementResult:
     """
     Get the result from the refinement.
@@ -229,6 +245,7 @@ def get_result(control_file: Path) -> RefinementResult:
     try:
         sav_text = control_file.read_text()
         phase_names = re.findall(r"STRUC\[\d+]=(.+?)\.str", sav_text)
+        phase_names = _dedupe_phase_names(phase_names)
 
         lst_path = control_file.parent / f"{control_file.stem}.lst"
         dia_path = control_file.parent / f"{control_file.stem}.dia"
@@ -311,7 +328,8 @@ def parse_lst(lst_path: Path, phase_names: list[str]) -> LstResult:
 
     Returns
     -------
-        phase_results: a dictionary of the results for each phase
+        phase_results: a dictionary of the results for each phase.
+            Duplicate input names should be disambiguated by the caller.
 
     """
 

--- a/tests/test_cif2str.py
+++ b/tests/test_cif2str.py
@@ -36,15 +36,15 @@ class TestCif2Str(unittest.TestCase):
                 self.assertTrue(ref_phase_name == phase_name)
 
     def test_cif2str_custom_params(self):
-        """Test the cif2str function with custom_lines and element_params_map."""
+        """Test the cif2str function with custom_params and custom_params_map."""
         if not self.cif_paths:
             self.skipTest("No CIF files found for testing.")
 
         # Just use the first available CIF for this test
         cif_path = self.cif_paths[0]
         
-        custom_lines = ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
-        element_params_map = {
+        custom_params = ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
+        custom_params_map = {
             "*": {"TDS": "Bglobal"},
             "O": {"TDS": "BO", "Occ": "OccO"}
         }
@@ -54,8 +54,8 @@ class TestCif2Str(unittest.TestCase):
             str_path = cif2str(
                 cif_path, 
                 working_dir=tmpdir, 
-                custom_lines=custom_lines, 
-                element_params_map=element_params_map
+                custom_params=custom_params, 
+                custom_params_map=custom_params_map
             )
 
             self.assertTrue(str_path.exists())
@@ -64,7 +64,7 @@ class TestCif2Str(unittest.TestCase):
                 content = f.read()
 
             # Verify that custom lines were successfully injected
-            for line in custom_lines:
+            for line in custom_params:
                 self.assertIn(line, content)
 
             # Verify the wildcard fallback applied Bglobal

--- a/tests/test_cif2str.py
+++ b/tests/test_cif2str.py
@@ -15,7 +15,7 @@ class TestCif2Str(unittest.TestCase):
         self.cif_paths = list((Path(__file__).parent / "test_data").glob("*.cif"))
 
     def test_cif2str(self):
-        """Test the cif2str function."""
+        """Test the cif2str function with default parameters."""
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
             for cif_path in self.cif_paths:
@@ -34,3 +34,46 @@ class TestCif2Str(unittest.TestCase):
                 ref_phase_name = read_phase_name_from_str(ref_str_path)
                 phase_name = read_phase_name_from_str(str_path)
                 self.assertTrue(ref_phase_name == phase_name)
+
+    def test_cif2str_custom_params(self):
+        """Test the cif2str function with custom_lines and element_params_map."""
+        if not self.cif_paths:
+            self.skipTest("No CIF files found for testing.")
+
+        # Just use the first available CIF for this test
+        cif_path = self.cif_paths[0]
+        
+        custom_lines = ["PARAM=Bglobal=0.05_0.01^0.20 //", "PARAM=BO=0.1_0.02^0.3 //"]
+        element_params_map = {
+            "*": {"TDS": "Bglobal"},
+            "O": {"TDS": "BO", "Occ": "OccO"}
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            str_path = cif2str(
+                cif_path, 
+                working_dir=tmpdir, 
+                custom_lines=custom_lines, 
+                element_params_map=element_params_map
+            )
+
+            self.assertTrue(str_path.exists())
+
+            with open(str_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Verify that custom lines were successfully injected
+            for line in custom_lines:
+                self.assertIn(line, content)
+
+            # Verify the wildcard fallback applied Bglobal
+            self.assertIn("TDS=Bglobal", content)
+
+            # Verify that the hardcoded room-temp TDS was completely overwritten by the wildcard
+            self.assertNotIn("TDS=0.010000", content)
+
+            # If the test CIF happens to contain oxygen, verify the specific element overrides took precedence
+            if "E=O" in content or "O-" in content or "O+" in content:
+                self.assertIn("TDS=BO", content)
+                self.assertIn("Occ=OccO", content)

--- a/tests/test_cif2str.py
+++ b/tests/test_cif2str.py
@@ -21,6 +21,7 @@ class TestCif2Str(unittest.TestCase):
             for cif_path in self.cif_paths:
                 with warnings.catch_warnings(record=True) as w:
                     warnings.simplefilter("always")
+                    warnings.filterwarnings("ignore", category=FutureWarning)
                     str_path = cif2str(cif_path, "", tmpdir)
                     self.assertTrue(len(w) == 0)
 


### PR DESCRIPTION
## Summary

Major changes:

- feature 1: Added the custom_lines argument to the cif2str function to support injecting arbitrary BGMN string parameters, mathematical equations, and defect models directly into the generated .str files.
- feature 2: Added the element_params_map argument (typed as dict[str, dict]) to dynamically override or add parameters to specific Wyckoff lines. By using Python's .update() method, this cleanly removes the previous reliance on the hardcoded TDS string, allowing users to explicitly define independent parameters like {"TDS": "BO", "Occ": "OccO"} per element. Includes wildcard (*) support to easily apply global variables across the entire crystal structure.
- feature 3: can now specify an asymmetric lattice range via tuples (min, max), where min and max can be both positive or negative
- feature 4: can now specify a range of gewicht, to enforce presence of phase when refinement doesn't work
- 
- fix 1: Resolved the limitation where high-temperature refinements (e.g., alpha-phase K2CO3 near its melting point) would lead to poor refinements due to the rigid, hardcoded room-temperature TDS=0.010000 default.
- fix 2: When refining multiple instances of the same phase, it now correctly saves both by adding the "_dup" suffix to one of them 

## Todos

If this is work in progress, what else needs to be done?

- fix 3: Verify that Occupancy can actually be refined


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [x] All existing tests pass.
- [x] Tests have been added for any new features/fixes.
- [x] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

