### PR TITLE
Portable BGMN threading/parallelism + fit-aware intensity-order pruning

### DIFF
--- a/src/dara/generate_control_file.py
+++ b/src/dara/generate_control_file.py
@@ -10,7 +10,10 @@ from typing import Literal
 
 import numpy as np
 
+from dara.settings import DaraSettings
 from dara.utils import read_phase_name_from_str
+
+_DARA_SETTINGS = DaraSettings()
 
 
 def copy_instrument_files(instrument_profile: str | Path, working_dir: Path) -> str:
@@ -71,7 +74,7 @@ def generate_control_file(
     instrument_profile: str | Path,
     working_dir: Path | None = None,
     *,
-    n_threads: int = 8,
+    n_threads: int = _DARA_SETTINGS.BGMN_N_THREADS,
     wmin: float | None = None,
     wmax: float | None = None,
     eps1: float | str = 0.0,

--- a/src/dara/hardware.py
+++ b/src/dara/hardware.py
@@ -1,0 +1,40 @@
+"""Runtime CPU-core detection, used to size worker/thread counts portably."""
+
+from __future__ import annotations
+
+import os
+
+
+def detect_cpu_count() -> int:
+    """Detect the number of CPU cores usable by this process.
+
+    Checked in priority order:
+        1. SLURM_CPUS_PER_TASK, then SLURM_CPUS_ON_NODE (SLURM-managed jobs).
+        2. ``os.sched_getaffinity(0)`` (Linux only; reflects taskset/affinity
+           restrictions that ``os.cpu_count()`` ignores).
+        3. ``os.cpu_count()``.
+
+    Returns
+    -------
+        A positive integer. Falls back to 1 if nothing above yields a usable count.
+    """
+    for env_var in ("SLURM_CPUS_PER_TASK", "SLURM_CPUS_ON_NODE"):
+        value = os.environ.get(env_var)
+        if value:
+            try:
+                count = int(value)
+            except ValueError:
+                count = 0
+            if count > 0:
+                return count
+
+    if hasattr(os, "sched_getaffinity"):
+        count = len(os.sched_getaffinity(0))
+        if count > 0:
+            return count
+
+    count = os.cpu_count()
+    if count:
+        return count
+
+    return 1

--- a/src/dara/result.py
+++ b/src/dara/result.py
@@ -385,7 +385,7 @@ def parse_lst(lst_path: Path, phase_names: list[str]) -> LstResult:
 
     """
 
-    def parse_values(v_: str) -> float | tuple[float, float] | None | str | int:
+    def parse_values(v_: str) -> float | tuple[float, float] | str | int | None:
         try:
             v_ = v_.strip("%")
             if v_ == "ERROR" or v_ == "UNDEF":

--- a/src/dara/search/core.py
+++ b/src/dara/search/core.py
@@ -11,12 +11,17 @@ import ray
 
 from dara.search.data_model import PeakMatchingStrategy
 from dara.search.tree import BaseSearchTree, SearchTree
+from dara.settings import DaraSettings
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from dara.refine import RefinementPhase
     from dara.search.data_model import SearchResult
+
+_DARA_SETTINGS = DaraSettings()
+BGMN_N_THREADS = _DARA_SETTINGS.BGMN_N_THREADS
+RAY_NUM_CPUS = _DARA_SETTINGS.RAY_NUM_CPUS
 
 DEFAULT_PHASE_PARAMS = {
     "gewicht": "0_0",
@@ -26,11 +31,11 @@ DEFAULT_PHASE_PARAMS = {
     "b1": "0_0^0.005",
     "rp": 4,
 }
-DEFAULT_REFINEMENT_PARAMS = {"n_threads": 8, "eps1": 0, "eps2": "0_-0.05^0.05"}
+DEFAULT_REFINEMENT_PARAMS = {"n_threads": BGMN_N_THREADS, "eps1": 0, "eps2": "0_-0.05^0.05"}
 DEFAULT_PEAK_MATCHING_STRATEGY = PeakMatchingStrategy.default()
 
 
-@ray.remote
+@ray.remote(num_cpus=0)
 def _remote_expand_node(search_tree: BaseSearchTree) -> BaseSearchTree:
     """Expand a node in the search tree."""
     try:
@@ -100,7 +105,7 @@ def search_phases(
         refinement_params = {}
 
     if not ray.is_initialized():
-        ray.init(runtime_env={"working_dir": None})
+        ray.init(runtime_env={"working_dir": None}, num_cpus=RAY_NUM_CPUS)
 
     phase_params = {**DEFAULT_PHASE_PARAMS, **phase_params}
     refinement_params = {**DEFAULT_REFINEMENT_PARAMS, **refinement_params}

--- a/src/dara/search/tree.py
+++ b/src/dara/search/tree.py
@@ -20,6 +20,7 @@ from dara.peak_detection import detect_peaks
 from dara.refine import RefinementPhase
 from dara.search.data_model import PeakMatchingStrategy, SearchNodeData, SearchResult
 from dara.search.peak_matcher import PeakMatcher
+from dara.settings import DaraSettings
 from dara.utils import (
     estimate_rpb_threshold,
     find_optimal_intensity_threshold,
@@ -39,8 +40,15 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__, level="INFO")
 
+_DARA_SETTINGS = DaraSettings()
+BGMN_N_THREADS = _DARA_SETTINGS.BGMN_N_THREADS
 
-@ray.remote(num_cpus=1)
+#: Minimum relative Rwp improvement (parent -> child) required for a branch
+#: flagged by the intensity-order heuristic to survive anyway.
+MATERIAL_RWP_IMPROVEMENT = 0.08
+
+
+@ray.remote
 def remote_do_refinement_no_saving(
     pattern_path: Path,
     cif_paths: list[Path],
@@ -130,7 +138,7 @@ def batch_refinement(
     refinement_params: dict[str, float] | None = None,
 ) -> list[RefinementResult]:
     handles = [
-        remote_do_refinement_no_saving.remote(
+        remote_do_refinement_no_saving.options(num_cpus=BGMN_N_THREADS).remote(
             pattern_path,
             cif_paths,
             wavelength=wavelength,
@@ -211,6 +219,49 @@ def calculate_fom_and_strain(
     return (1 / (result.lst_data.rho + a * delta_u + 1e-4) + b * geweicht) / (
         1 + c
     ), lattice_strain
+
+
+def keep_branch_despite_intensity_order(
+    parent_result: RefinementResult | None,
+    child_result: RefinementResult,
+    *,
+    violated: bool,
+) -> bool:
+    """Decide whether an intensity-order violation should still prune a branch.
+
+    The intensity-order heuristic (unchanged, computed by the caller) flags a
+    branch when the newly added phase ends up with more peak intensity than a
+    phase added earlier. That's usually a sign the new phase isn't earning its
+    place, but it can also happen on a branch whose overall fit is clearly
+    better. Rather than pruning every flagged branch outright, only prune it
+    if it did not also improve Rwp by at least ``MATERIAL_RWP_IMPROVEMENT``
+    relative to its parent.
+
+    Args:
+        parent_result: the refinement result before the candidate phase was
+            added, or ``None`` at the root of the search tree.
+        child_result: the refinement result after adding the candidate phase.
+        violated: whether the (unchanged, caller-computed) intensity-order
+            check flagged this branch.
+
+    Returns
+    -------
+        True if the branch should survive (either unflagged, or flagged but
+        with a material Rwp improvement); False if it should be pruned.
+    """
+    if not violated:
+        return True
+
+    if parent_result is None:
+        return False
+
+    parent_rwp = parent_result.refinement_metrics.rwp
+    if not parent_rwp:
+        return False
+
+    child_rwp = child_result.refinement_metrics.rwp
+    rel_improvement = (parent_rwp - child_rwp) / parent_rwp
+    return rel_improvement >= MATERIAL_RWP_IMPROVEMENT
 
 
 def group_phases(
@@ -535,7 +586,11 @@ class BaseSearchTree(Tree):
                     != len(new_phases)
                 ):
                     status = "no_improvement"
-                elif is_low_weight_fraction:
+                elif not keep_branch_despite_intensity_order(
+                    parent_result=node.data.current_result,
+                    child_result=new_result,
+                    violated=is_low_weight_fraction,
+                ):
                     status = "low_weight_fraction"
                 elif not is_best_result_in_group:
                     status = "similar_structure"

--- a/src/dara/settings.py
+++ b/src/dara/settings.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from dara.hardware import detect_cpu_count
+
 _DEFAULT_CONFIG_FILE_PATH = "~/.dara.yaml"
 
 
@@ -22,6 +24,20 @@ class DaraSettings(BaseSettings):
 
     PATH_TO_ICSD: Path = Field(Path("~/ICSD_2024/ICSD_2024_experimental_inorganic/experimental_inorganic").expanduser())
     PATH_TO_COD: Path = Field(Path("~/COD_2024").expanduser())
+
+    BGMN_N_THREADS: int = Field(
+        1,
+        description="Number of internal threads BGMN uses per refinement. Kept at 1 by "
+        "default so worker parallelism (RAY_NUM_CPUS) doesn't oversubscribe the machine's "
+        "cores. Override with the DARA_BGMN_N_THREADS env var.",
+    )
+    RAY_NUM_CPUS: int = Field(
+        default_factory=detect_cpu_count,
+        description="Number of CPUs Ray is told it has available, passed explicitly to "
+        "ray.init() so it doesn't auto-detect (which grabs the whole node under SLURM). "
+        "Defaults to the runtime-detected usable core count. Override with the "
+        "DARA_RAY_NUM_CPUS env var.",
+    )
 
     model_config = SettingsConfigDict(env_prefix="dara_")  # prepend dara_ to env vars
 

--- a/src/dara/utils.py
+++ b/src/dara/utils.py
@@ -55,7 +55,7 @@ def bool2yn(value: bool) -> str:
     return "Y" if value else "N"
 
 
-def get_number(s: Union[float, None, tuple[float, float]]) -> Union[float, None]:
+def get_number(s: Union[float, tuple[float, float], None]) -> Union[float, None]:
     """Get the number from a float or tuple of floats."""
     if isinstance(s, tuple):
         return s[0]

--- a/tests/test_search_tree.py
+++ b/tests/test_search_tree.py
@@ -1,0 +1,176 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+from treelib import Node
+
+from dara.refine import RefinementPhase
+from dara.result import DiaResult, LstResult, RefinementMetrics, RefinementResult
+from dara.search.data_model import SearchNodeData
+from dara.search.tree import (
+    MATERIAL_RWP_IMPROVEMENT,
+    BaseSearchTree,
+    keep_branch_despite_intensity_order,
+)
+
+
+def _phase(name: str) -> RefinementPhase:
+    return RefinementPhase.make(Path(f"/fake/cifs/{name}.cif"))
+
+
+def _make_result(rwp: float, rpb_value: float | None = None, peak_rows=None) -> RefinementResult:
+    """Build a minimal but genuinely valid (pydantic-validated) RefinementResult.
+
+    Only ``rwp``/``rpb`` and (for the integration test) ``peak_data`` are
+    exercised by the code under test; everything else is a structurally
+    valid placeholder.
+    """
+    if rpb_value is None:
+        rpb_value = rwp
+    return RefinementResult(
+        lst_data=LstResult(
+            raw_lst="",
+            pattern_name="fake",
+            num_steps=1,
+            rp=0.0,
+            rpb=rpb_value,
+            r=0.0,
+            rwp=rwp,
+            rexp=1.0,
+            d=0.0,
+            rho=rpb_value,
+            phases_results={},
+        ),
+        plot_data=DiaResult(x=[0.0], y_obs=[0.0], y_calc=[0.0], y_bkg=[0.0], structs={}),
+        peak_data=pd.DataFrame(
+            peak_rows or [{"phase": "", "2theta": 0.0, "intensity": 0.0}]
+        ),
+        refinement_metrics=RefinementMetrics(rwp=rwp),
+    )
+
+
+class TestKeepBranchDespiteIntensityOrder(unittest.TestCase):
+    """Direct unit tests for the pure helper (Change 2)."""
+
+    def test_not_violated_always_kept(self):
+        parent = _make_result(rwp=50.0)
+        child = _make_result(rwp=49.9)
+        self.assertTrue(keep_branch_despite_intensity_order(parent, child, violated=False))
+
+    def test_violated_with_material_improvement_kept(self):
+        # 50 -> 40 is a 20% relative improvement, above the 8% threshold.
+        parent = _make_result(rwp=50.0)
+        child = _make_result(rwp=40.0)
+        self.assertTrue(keep_branch_despite_intensity_order(parent, child, violated=True))
+
+    def test_violated_with_marginal_improvement_pruned(self):
+        # 50 -> 48 is a 4% relative improvement, below the 8% threshold.
+        parent = _make_result(rwp=50.0)
+        child = _make_result(rwp=48.0)
+        self.assertFalse(keep_branch_despite_intensity_order(parent, child, violated=True))
+
+    def test_improvement_exactly_at_threshold_is_kept(self):
+        parent_rwp = 50.0
+        child_rwp = parent_rwp * (1 - MATERIAL_RWP_IMPROVEMENT)
+        parent = _make_result(rwp=parent_rwp)
+        child = _make_result(rwp=child_rwp)
+        self.assertTrue(keep_branch_despite_intensity_order(parent, child, violated=True))
+
+    def test_violated_with_no_parent_falls_back_to_prune(self):
+        child = _make_result(rwp=10.0)
+        self.assertFalse(keep_branch_despite_intensity_order(None, child, violated=True))
+
+    def test_violated_with_zero_parent_rwp_falls_back_to_prune(self):
+        parent = _make_result(rwp=0.0)
+        child = _make_result(rwp=0.0)
+        self.assertFalse(keep_branch_despite_intensity_order(parent, child, violated=True))
+
+
+class TestExpandNodeIntensityOrderIntegration(unittest.TestCase):
+    """Exercise the real ``expand_node`` status decision (Change 2), not just the helper.
+
+    ``score_phases``/``refine_phases`` (heavy, would otherwise run BGMN) and the
+    unrelated overfitting check (``remove_unnecessary_phases``, which needs
+    realistic plot data) are stubbed out. The intensity-order detection and the
+    material-improvement gate run for real.
+    """
+
+    def setUp(self):
+        self.phase_a = _phase("A")
+        self.phase_b = _phase("B")
+
+    def _build_tree(self, parent_result: RefinementResult) -> BaseSearchTree:
+        tree = BaseSearchTree(
+            pattern_path=Path("/fake/pattern.xy"),
+            all_phases_result={self.phase_b: _make_result(rwp=1.0)},
+            peak_obs=np.array([[10.0, 500.0], [20.0, 300.0]]),
+            refine_params={},
+            phase_params={},
+            intensity_threshold=0.0,
+            wavelength="Cu",
+            instrument_profile="fake",
+            express_mode=False,
+            maximum_grouping_distance=0.1,
+            max_phases=5,
+            rpb_threshold=0.0,
+            pinned_phases=[],
+            record_peak_matcher_scores=False,
+            peak_matching_strategy=None,
+        )
+        tree.add_node(
+            Node(
+                identifier="root",
+                data=SearchNodeData(
+                    current_result=parent_result, current_phases=[self.phase_a]
+                ),
+            )
+        )
+        return tree
+
+    def _expand_with_child_rwp(self, parent_rwp: float, child_rwp: float) -> str:
+        parent_result = _make_result(rwp=parent_rwp)
+        # phase B (newly added) has more peak intensity than phase A (added
+        # earlier) -> flags the intensity-order heuristic.
+        child_result = _make_result(
+            rwp=child_rwp,
+            peak_rows=[
+                {"phase": "A", "2theta": 10.0, "intensity": 50.0},
+                {"phase": "B", "2theta": 20.0, "intensity": 500.0},
+            ],
+        )
+
+        tree = self._build_tree(parent_result)
+        tree.score_phases = lambda all_phases_result, current_result: ([self.phase_b], {}, 0.0)
+        tree.refine_phases = lambda best_phases, pinned_phases: {self.phase_b: child_result}
+
+        new_phases = [self.phase_a, self.phase_b]
+        with (
+            patch(
+                "dara.search.tree.group_phases",
+                return_value={self.phase_b: {"group_id": 0, "fom": 1.0, "lattice_strain": 0.0}},
+            ),
+            patch(
+                "dara.search.tree.remove_unnecessary_phases",
+                return_value=[p.path for p in new_phases],
+            ),
+        ):
+            tree.expand_node("root")
+
+        child_nid = next(nid for nid in tree.expand_tree("root") if nid != "root")
+        return tree.get_node(child_nid).data.status
+
+    def test_intensity_order_violation_with_material_improvement_is_kept(self):
+        # 50 -> 30 is a 40% relative improvement: well above the threshold.
+        status = self._expand_with_child_rwp(parent_rwp=50.0, child_rwp=30.0)
+        self.assertEqual(status, "pending")
+
+    def test_intensity_order_violation_below_threshold_is_pruned(self):
+        # 50 -> 48 is a 4% relative improvement: below the threshold.
+        status = self._expand_with_child_rwp(parent_rwp=50.0, child_rwp=48.0)
+        self.assertEqual(status, "low_weight_fraction")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Change 1 — Bound BGMN threads, keep worker parallelism (portable):
- New src/dara/hardware.py detects usable cores (SLURM env vars → os.sched_getaffinity → os.cpu_count).
- settings.py adds BGMN_N_THREADS (default 1, env DARA_BGMN_N_THREADS) and RAY_NUM_CPUS (default = detected cores, env DARA_RAY_NUM_CPUS).
- BGMN now runs 1 thread per refinement instead of 8, avoiding cores×8 OS-thread oversubscription. ray.init pins num_cpus=RAY_NUM_CPUS (SLURM-safe); the inner BGMN task uses .options(num_cpus=BGMN_N_THREADS); the outer orchestration task uses num_cpus=0 so it no longer pins a core while blocked, freeing all cores for BGMN refinements (concurrency ≈ cores/threads).
- generate_control_file default n_threads now sourced from BGMN_N_THREADS.

Change 2 — Don't discard a better-fitting branch on the intensity-order heuristic:
- Existing intensity-order / low-weight-fraction detection is unchanged.
- A flagged branch is now pruned only if it did NOT improve Rwp by at least 8% vs its parent (MATERIAL_RWP_IMPROVEMENT = 0.08), via the pure helper keep_branch_despite_intensity_order, guarded against missing/zero parent Rwp.
- New tests/test_search_tree.py covers the helper and integration paths.

## Summary

Major changes:

- feature 1: ...
- fix 1: ...

## Todos

If this is work in progress, what else needs to be done?

- feature 2: ...
- fix 2:


## Checklist

<!---Before a pull request can be merged, the following items must be checked:-->

- [ ] All existing tests pass.
- [ ] Tests have been added for any new features/fixes.
- [ ] Docstrings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
